### PR TITLE
Ensure file exists

### DIFF
--- a/site.rb
+++ b/site.rb
@@ -61,7 +61,7 @@ end
 
 get '/blog/:key' do
   filename = Dir::glob("blog/**/#{params[:key]}.markdown").first
-  unless filename
+  unless File.exists?(filename)
     status 404
     return haml :error, locals: { area: 'Blog', title: 'Post not found', message: 'Sorry, that post doesn\'t exist.' }
   end


### PR DESCRIPTION
Thought I'd demo github's collaborative workflow to you!

I've forked your repo, cloned it to my computer, made some changes (to the master branch, which is unusual) and now I'm submitting them back to you for approval/inclusion in the form of a pull request.

The change I made is a slight alteration to the `/blog/:key` route - if a key is given which doesn't have a file, currently you'll get a file not found error, which will throw up a not very friendly error page. Adding the test for the file existing ensures that your 404 will show if the key is invalid.
