### PR TITLE
Error block

### DIFF
--- a/site.rb
+++ b/site.rb
@@ -13,6 +13,10 @@ RFC822_DATE_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
 
 # ------------------------------------------------------------------------------
 
+error 404 do
+  haml :error, locals: { area: 'Blog', title: 'Post not found', message: "Sorry, that post doesn't exist." }
+end
+
 get '/css/:style.css' do
   less params[:style].to_sym
 end
@@ -61,10 +65,7 @@ end
 
 get '/blog/:key' do
   filename = Dir::glob("blog/**/#{params[:key]}.markdown").first
-  unless File.exists?(filename)
-    status 404
-    return haml :error, locals: { area: 'Blog', title: 'Post not found', message: 'Sorry, that post doesn\'t exist.' }
-  end
+  halt 404 unless filename
   haml :'blog/post', locals: blog_post(filename).merge({ area: 'Blog' })
 end
 


### PR DESCRIPTION
I've swapped your code around to use a generic 404 handler. It cleans up the code in the `/blog/:key` route, and will also catch badly formed URLs like `/nothinghere` (which may or may not be what you want…)
